### PR TITLE
When gridta and gridtd rasters are processed, we use the geotransform fr...

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,14 @@ Changelog of flooding-lib
 2.96 (unreleased)
 -----------------
 
-- Nothing changed yet.
+- Set Django version to 1.4.8 in buildout (only for testing), because
+  the tests fail with 1.5+.
+
+- When gridta and gridtd rasters are processed, we use the
+  geotransform from the max waterdepth grids, as that is always
+  correct while the gridta and gridtd's are sometimes wrong.
+
+- Add some helper functions and tests.
 
 
 2.95 (2013-09-24)

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -32,6 +32,7 @@ eggs =
 
 
 [versions]
+Django = 1.4.8
 flooding-lib =
 Markdown = 2.2.0
 buildout-versions = 1.5.0

--- a/flooding_lib/models.py
+++ b/flooding_lib/models.py
@@ -1748,6 +1748,18 @@ class Result(models.Model):
         verbose_name_plural = _('Results')
         db_table = 'flooding_result'
 
+    @property
+    def absolute_resultloc(self):
+        """Return absolute location, as a byte string, with path
+        separators for this OS."""
+        dest_dir = Setting.objects.get(key='destination_dir').value
+        abspath = os.path.join(dest_dir, self.resultloc)
+        if os.path.sep == '/':
+            abspath = abspath.replace('\\', '/')
+        else:
+            abspath = abspath.replace('/', '\\')
+        return abspath.encode('utf8')
+
     def __unicode__(self):
         return (
             '{t} for scenario {i} ({n})'

--- a/flooding_lib/tasks/tests/test_calculate_export_maps.py
+++ b/flooding_lib/tasks/tests/test_calculate_export_maps.py
@@ -1,0 +1,46 @@
+from django.test import TestCase
+
+import mock
+
+from flooding_lib.tasks import calculate_export_maps
+
+
+def cem(attr):
+    """Helper function for patch, because the module name is so long."""
+    return 'flooding_lib.tasks.calculate_export_maps.{attr}'.format(attr=attr)
+
+
+class TestAllFilesIn(TestCase):
+    @mock.patch(cem('is_valid_zipfile'), return_value=False)
+    @mock.patch('os.path.isfile', return_value=False)
+    def test_non_existing_file_returns_nothing(self, patched1, patched2):
+        self.assertEquals(
+            list(calculate_export_maps.all_files_in('/some/file/name')),
+            [])
+
+    @mock.patch(cem('is_valid_zipfile'), return_value=False)
+    @mock.patch('os.path.isfile', return_value=True)
+    def test_existing_nonzip_file_returns_str(self, patched1, patched2):
+        filename = u'filename'
+
+        allfiles = list(calculate_export_maps.all_files_in(filename))
+
+        self.assertEquals(len(allfiles), 1)
+        self.assertEquals(allfiles[0], "filename")
+        self.assertTrue(isinstance(allfiles[0], str))
+
+    @mock.patch(cem('is_valid_zipfile'), return_value=True)
+    def test_returns_files_in_zip(self, patched):
+        files = ["file1", "file2"]
+
+        mocked_unzipped = mock.MagicMock()
+        mocked_unzipped.__enter__.return_value = mocked_unzipped
+        mocked_unzipped.__iter__.return_value = iter(files)
+
+        with mock.patch(
+            'flooding_lib.util.files.temporarily_unzipped',
+            return_value=mocked_unzipped):
+            files2 = list(
+                calculate_export_maps.all_files_in('/some/file/name'))
+
+        self.assertEquals(files, files2)

--- a/flooding_lib/tools/exporttool/models.py
+++ b/flooding_lib/tools/exporttool/models.py
@@ -163,15 +163,23 @@ class ExportRun(models.Model):
             'dijkringnr': a region's dijkring number,
             'filename': the file containing this result type
 
-        For each of this object's scenarios, for each of the regions of those scenarios,
-        for the given result type.
+        For each of this object's scenarios, for each of the regions
+        of those scenarios, for the given result type (name or
+        resulttype instance).
         """
         dest_dir = BaseSetting.objects.get(key='destination_dir').value
+
+        if isinstance(export_result_type, basestring):
+            # Name of result type given
+            resulttype_filter = {'resulttype__name': export_result_type}
+        else:
+            # Result type itself
+            resulttype_filter = {'resulttype': export_result_type}
 
         result = []
         for s in self.scenarios.all():
             for r in Region.objects.filter(breach__scenario=s):
-                for rs in s.result_set.filter(resulttype=export_result_type):
+                for rs in s.result_set.filter(**resulttype_filter):
                     result.append({
                             'scenario': s,
                             'dijkringnr': r.dijkringnr,


### PR DESCRIPTION
...om the max waterdepth grids, as that is always correct while the gridta and gridtd's are sometimes wrong.

Dit los het probleem met all_files_in() op, en daarnaast een bug met de extents in de gegenereerde aankomsttijden kaarten.
