### PR TITLE
Verkerk more permissions

### DIFF
--- a/flooding_lib/tasks/calculate_export_data.py
+++ b/flooding_lib/tasks/calculate_export_data.py
@@ -9,7 +9,6 @@ from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
 
-from stat import S_IRUSR, S_IWUSR, S_IRGRP, S_IROTH
 import csv
 import os
 import shutil
@@ -18,6 +17,7 @@ import tempfile
 from flooding_lib.conf import settings
 
 from flooding_lib.tools.exporttool.models import ExportRun
+from flooding_lib.util import files
 
 import logging
 logger = logging.getLogger(__name__)
@@ -59,7 +59,7 @@ def calculate_export_data(export_run_id):
     zipf = dirs_into_zipfile(tempdir, export_run.generate_dst_path())
 
     # Make the zipfile readable for the Web server
-    make_file_readable_for_all(zipf)
+    files.make_file_readable_for_all(zipf)
     # Record this zipfile as the result of the export run
     logger.info("Storing zip file as export run result.")
     export_run.save_result_file(zipf)
@@ -197,21 +197,3 @@ def dirs_into_zipfile(tempdir, zipfile_path):
         zipfile_path = zipfile_path[:-4]
 
     return shutil.make_archive(zipfile_path, "zip", tempdir)
-
-
-def make_file_readable_for_all(filepath):
-    """This must be done to make the file readable to Nginx.
-
-    The same goal could be achieved by changing the group of
-    the file to 'www-data' and giving only the group read
-    permissions, but user buildout is not part of www-data and
-    therefore isn't allowed to do that. The below seems to be
-    the lesser evil."""
-
-    try:
-        os.chmod(filepath, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH)
-    except OSError as e:
-        # Only log
-        logger.error(
-            'OSError as we tried to change export result permissions:',
-            str(e))

--- a/flooding_lib/tasks/calculate_export_maps.py
+++ b/flooding_lib/tasks/calculate_export_maps.py
@@ -797,6 +797,9 @@ def calculate_export_maps(exportrun_id):
 
     shutil.move(tmp_zip_filename, dst_path)
 
+    # Make the zipfile readable for the Web server
+    files.make_file_readable_for_all(dst_path)
+
     result_count = Result.objects.filter(export_run=export_run).count()
     if result_count > 0:
         log.warn('Warning: deleting old Result objects for this export run...')

--- a/flooding_lib/tools/importtool/models.py
+++ b/flooding_lib/tools/importtool/models.py
@@ -6,14 +6,12 @@ import os
 import os.path
 import re
 import xlrd
-from shutil import copyfile
 
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.contrib.gis.db import models
 from django.utils.translation import ugettext_lazy as _
 
-from flooding_base.models import Setting
 from flooding_lib.dates import get_dayfloat_from_intervalstring
 from flooding_lib.dates import get_intervalstring_from_dayfloat
 from flooding_lib.models import Breach
@@ -236,8 +234,12 @@ class ImportScenario(models.Model):
                 extrainfofield=extrainfofield,
                 scenario=self.scenario,
                 defaults={"value": " "})
-            extrascenarioinfo.value = str(
-                extra_scenario_info[extra_field_name])
+            original_value = extra_scenario_info[extra_field_name]
+            try:
+                encoded_value = str(original_value)
+            except UnicodeEncodeError:
+                encoded_value = original_value.encode('utf-8')
+            extrascenarioinfo.value = encoded_value
             extrascenarioinfo.save()
 
     def copy_result_files(self, result_values):


### PR DESCRIPTION
And handle some more special characters in the exta scenarioinfofield thing. Because my testdata happended to contain 'Eén of andere archaïsche 3Di versie', and it seemed appropriate to allow for such things.